### PR TITLE
Refactor get_code() to be atomic

### DIFF
--- a/default_settings.py
+++ b/default_settings.py
@@ -1,7 +1,10 @@
 DEBUG = False
 
+# This setting must be set only the first time you start to store URLs
 ALPHABET = 'h6sCQgcPqJNrSzlWn5TfeBK8HxiY1Z7kIap3yXODMbvVt0m2udjRU4GEFoL9Aw'
 
 REDIS_HOST = 'localhost'
 REDIS_PORT = 6379
 REDIS_DB = 0
+
+REDIS_COUNTER_ERRORS = 5

--- a/tamales_tests.py
+++ b/tamales_tests.py
@@ -3,8 +3,8 @@ import unittest
 
 
 class TamalesUtilsTestCase(unittest.TestCase):
-    def test_generate_code(self):
-        code = tamales.generate_code()
+    def test_get_code(self):
+        code = tamales.get_code('http://www.example.com')
         char_one = tamales.app.config['ALPHABET'][1]
         self.assertEqual(char_one, code)
 


### PR DESCRIPTION
The get_code function now it's more atomic using redis transactions and avoid conflicts with the `counter` key and the URL keys.
